### PR TITLE
Replace custom proto traits with From

### DIFF
--- a/node/daemon/src/grpc/enclave_client.rs
+++ b/node/daemon/src/grpc/enclave_client.rs
@@ -9,7 +9,7 @@ use nxcc_interface::{
         TerminateWorkerRequest, VmAddress as ProtoVmAddress, runner_client::RunnerClient,
         secrets_client::SecretsClient,
     },
-    types::{AttestationReport, EnvReport, FromProto as _, IntoProto as _, SecretId, SecretsBox},
+    types::{AttestationReport, EnvReport, SecretId, SecretsBox},
 };
 use tokio::net::UnixStream;
 use tonic::{
@@ -69,7 +69,7 @@ impl EnclaveClient {
         let mut client = self.secrets();
         let req = GetReportRequest { user_data };
         let resp = client.get_report(req).await.map_err(|e| e.to_string())?;
-        Ok(AttestationReport::from_proto(resp.into_inner()))
+        Ok(AttestationReport::from(resp.into_inner()))
     }
 
     pub async fn put_secrets(
@@ -79,8 +79,8 @@ impl EnclaveClient {
         let mut bundles = Vec::new();
         for (sb, env_report) in bundles_with_reports {
             bundles.push(ProtoSecretsBundle {
-                secrets_box: Some(sb.to_proto()),
-                env_report: Some(env_report.to_proto()),
+                secrets_box: Some(sb.into()),
+                env_report: Some(env_report.into()),
             });
         }
         let req = PutSecretsRequest {
@@ -99,19 +99,19 @@ impl EnclaveClient {
         let mut requests = Vec::new();
         for sid in secret_ids {
             requests.push(SecretRequest {
-                id: Some(sid.to_proto()),
+                id: Some(sid.into()),
             });
         }
         let req = GetSecretsRequest {
             requests,
-            requester_env_report: Some(env_report.to_proto()),
+            requester_env_report: Some(env_report.into()),
             policy_reports: vec![], // not used yet
         };
         let mut client = self.secrets();
         let resp = client.get_secrets(req).await.map_err(|e| e.to_string())?;
         let out = resp.into_inner();
         if let Some(box_proto) = out.secrets_box {
-            Ok(SecretsBox::from_proto(box_proto))
+            Ok(SecretsBox::from(box_proto))
         } else {
             Err("Enclave returned no SecretsBox".to_string())
         }
@@ -123,7 +123,7 @@ impl EnclaveClient {
     ) -> Result<Vec<(SecretId, bool, u64)>, String> {
         let mut proto_ids = Vec::new();
         for sid in ids.iter() {
-            proto_ids.push(sid.to_proto());
+            proto_ids.push((*sid).clone().into());
         }
         let req = CheckSecretsRequest { ids: proto_ids };
         let mut client = self.secrets();
@@ -132,7 +132,7 @@ impl EnclaveClient {
         let mut out = Vec::new();
         for st in statuses {
             if let Some(proto_id) = st.id {
-                let sid = SecretId::from_proto(proto_id);
+                let sid = SecretId::from(proto_id);
                 out.push((sid, st.found, st.expiry));
             }
         }
@@ -140,7 +140,7 @@ impl EnclaveClient {
     }
 
     pub async fn generate_secrets(&self, ids: Vec<SecretId>) -> Result<(), String> {
-        let proto_ids = ids.iter().map(|id| id.to_proto()).collect();
+        let proto_ids = ids.into_iter().map(Into::into).collect();
         let req = GenerateSecretsRequest { ids: proto_ids };
         let mut client = self.secrets();
         client
@@ -217,7 +217,7 @@ impl EnclaveClient {
         worker_id: String,
         contexts: Vec<nxcc_interface::types::PolicyExecutionRequest>,
     ) -> Result<Vec<nxcc_interface::types::PolicyExecutionRequest>, String> {
-        let proto_contexts = contexts.iter().map(|c| c.to_proto()).collect();
+        let proto_contexts = contexts.iter().cloned().map(Into::into).collect();
         let req = ProtoExecutePolicyRequest {
             worker_id,
             contexts: proto_contexts,
@@ -231,7 +231,7 @@ impl EnclaveClient {
         let satisfied = resp
             .satisfied_contexts
             .into_iter()
-            .map(nxcc_interface::types::PolicyExecutionRequest::from_proto)
+            .map(nxcc_interface::types::PolicyExecutionRequest::from)
             .collect();
         Ok(satisfied)
     }

--- a/node/daemon/src/grpc/secrets.rs
+++ b/node/daemon/src/grpc/secrets.rs
@@ -5,10 +5,7 @@ use nxcc_interface::{
         AttachVmRequest, AttachVmResponse, GetSecretsRequest, GetSecretsResponse,
         secrets_server::Secrets,
     },
-    types::{
-        AttestationReport, EnvReport, FromProto as _, IntoProto as _, SecretId, SecretRequest,
-        SecretsBox,
-    },
+    types::{AttestationReport, EnvReport, SecretId, SecretRequest, SecretsBox},
 };
 use tonic::{Request, Response, Status};
 use tracing::{debug, error, info};
@@ -44,7 +41,7 @@ impl Secrets for SecretsDebugGrpc {
         let mut grouped_requests = HashMap::new();
         let mut all_secret_ids = Vec::new(); // Collect all requested IDs for the final fetch
         for proto_req in req.secret_requests {
-            let sr = SecretRequest::from_proto(proto_req);
+            let sr = SecretRequest::from(proto_req);
             all_secret_ids.push(sr.secret_id.clone());
             grouped_requests
                 .entry(sr.secret_id.clone())
@@ -95,7 +92,7 @@ impl Secrets for SecretsDebugGrpc {
                     Ok(secrets_box) => {
                         info!("Successfully retrieved final SecretsBox from enclave.");
                         let resp = GetSecretsResponse {
-                            secrets_box: Some(secrets_box.to_proto()),
+                            secrets_box: Some(secrets_box.into()),
                         };
                         Ok(Response::new(resp))
                     }

--- a/node/daemon/src/services/runner.rs
+++ b/node/daemon/src/services/runner.rs
@@ -4,7 +4,7 @@ use nxcc_interface::{
         ExecutePolicyRequest as ProtoExecutePolicyRequest, RunWorkerRequest,
         TerminateWorkerRequest, runner_client::RunnerClient,
     },
-    types::{EnvReport, FromProto as _, IntoProto as _, PolicyExecutionRequest, SecretId},
+    types::{EnvReport, PolicyExecutionRequest, SecretId},
 };
 use tonic::transport::Channel;
 use tracing::{debug, info, warn};
@@ -89,7 +89,7 @@ impl RunnerService {
         worker_id: String,
         contexts: Vec<PolicyExecutionRequest>,
     ) -> Result<Vec<PolicyExecutionRequest>, AppError> {
-        let proto_contexts = contexts.iter().map(|c| c.to_proto()).collect();
+        let proto_contexts = contexts.iter().cloned().map(Into::into).collect();
         let req = ProtoExecutePolicyRequest {
             worker_id,
             contexts: proto_contexts,
@@ -103,7 +103,7 @@ impl RunnerService {
         let satisfied = resp
             .satisfied_contexts
             .into_iter()
-            .map(PolicyExecutionRequest::from_proto)
+            .map(PolicyExecutionRequest::from)
             .collect();
         Ok(satisfied)
     }

--- a/node/enclave/src/grpc.rs
+++ b/node/enclave/src/grpc.rs
@@ -13,9 +13,7 @@ use nxcc_interface::{
         },
         interface,
     },
-    types::{
-        EnvReport, FromProto, IntoProto, PolicyExecutionRequest, SecretId, SecretsBox, VmAddress,
-    },
+    types::{EnvReport, PolicyExecutionRequest, SecretId, SecretsBox, VmAddress},
 };
 use nxcc_vm_base::client::ClientError;
 use tonic::{Request, Response, Status, transport::Server};
@@ -51,7 +49,7 @@ impl SecretsServerTrait for SecretsGrpcService {
             user_data.len()
         );
         match self.secrets.get_report(user_data) {
-            Ok(report) => Ok(Response::new(report.to_proto())),
+            Ok(report) => Ok(Response::new(report.into())),
             Err(e) => {
                 error!("GetReport failed: {}", e);
                 Err(Status::internal(format!("Failed to get report: {e}")))
@@ -72,11 +70,11 @@ impl SecretsServerTrait for SecretsGrpcService {
         for bundle_proto in proto_req.secrets_bundles {
             let secrets_box = bundle_proto
                 .secrets_box
-                .map(SecretsBox::from_proto)
+                .map(SecretsBox::from)
                 .ok_or_else(|| Status::invalid_argument("Missing SecretsBox in bundle"))?;
             let env_report = bundle_proto
                 .env_report
-                .map(EnvReport::from_proto)
+                .map(EnvReport::from)
                 .ok_or_else(|| Status::invalid_argument("Missing EnvReport in bundle"))?;
             bundles.push((secrets_box, env_report));
         }
@@ -103,12 +101,12 @@ impl SecretsServerTrait for SecretsGrpcService {
         let secret_ids: Vec<SecretId> = proto_req
             .requests
             .into_iter()
-            .filter_map(|r| r.id.map(SecretId::from_proto))
+            .filter_map(|r| r.id.map(SecretId::from))
             .collect();
 
         let requester_env_report = proto_req
             .requester_env_report
-            .map(EnvReport::from_proto)
+            .map(EnvReport::from)
             .ok_or_else(|| Status::invalid_argument("Missing requester_env_report"))?;
 
         // Policy reports are currently unused, local auth store is checked
@@ -119,7 +117,7 @@ impl SecretsServerTrait for SecretsGrpcService {
             .get_secrets(secret_ids, requester_env_report, policy_reports)
         {
             Ok(secrets_box) => Ok(Response::new(GetSecretsResponse {
-                secrets_box: Some(secrets_box.to_proto()),
+                secrets_box: Some(secrets_box.into()),
             })),
             Err(e) => {
                 error!("GetSecrets failed: {}", e);
@@ -137,7 +135,7 @@ impl SecretsServerTrait for SecretsGrpcService {
         let ids: Vec<SecretId> = proto_req
             .ids
             .into_iter()
-            .map(SecretId::from_proto)
+            .map(SecretId::from)
             .collect();
 
         match self.secrets.check_secrets(ids) {
@@ -145,7 +143,7 @@ impl SecretsServerTrait for SecretsGrpcService {
                 let proto_statuses = statuses
                     .into_iter()
                     .map(|(id, found, expiry)| SecretStatus {
-                        id: Some(id.to_proto()),
+                        id: Some(id.into()),
                         found,
                         expiry,
                     })
@@ -173,7 +171,7 @@ impl SecretsServerTrait for SecretsGrpcService {
         let ids: Vec<SecretId> = proto_req
             .ids
             .into_iter()
-            .map(SecretId::from_proto)
+            .map(SecretId::from)
             .collect();
 
         match self.secrets.generate_secrets(ids) {
@@ -237,7 +235,7 @@ impl Runner for EnclaveRunnerGrpcService {
         debug!("gRPC AttachVm request for vm_id '{}'", req.vm_id);
         let address = req
             .address
-            .map(VmAddress::from_proto)
+            .map(VmAddress::from)
             .ok_or_else(|| Status::invalid_argument("Missing VM address"))?;
 
         match self.runner.attach_vm(req.vm_id, address).await {
@@ -346,7 +344,7 @@ impl Runner for EnclaveRunnerGrpcService {
         let internal_contexts: Vec<PolicyExecutionRequest> = req
             .contexts
             .into_iter()
-            .map(PolicyExecutionRequest::from_proto)
+            .map(PolicyExecutionRequest::from)
             .collect();
 
         match self
@@ -357,7 +355,7 @@ impl Runner for EnclaveRunnerGrpcService {
             Ok(satisfied_internal_contexts) => {
                 let satisfied_proto_contexts = satisfied_internal_contexts
                     .into_iter()
-                    .map(|ctx| ctx.to_proto())
+                    .map(Into::into)
                     .collect();
                 Ok(Response::new(ExecutePolicyResponse {
                     satisfied_contexts: satisfied_proto_contexts,

--- a/node/enclave/src/tests.rs
+++ b/node/enclave/src/tests.rs
@@ -13,8 +13,8 @@ use nxcc_interface::{
         secrets_server::Secrets as _,
     },
     types::{
-        AttestationReport, ConsumerInfo, EnvReport, FromProto as _, IntoProto as _,
-        PolicyExecutionReport, PolicyExecutionRequest, SecretId, SecretsBox,
+        AttestationReport, ConsumerInfo, EnvReport, PolicyExecutionReport,
+        PolicyExecutionRequest, SecretId, SecretsBox,
     },
 };
 use nxcc_vm_base::client::mock::{MockExecutionBehavior, MockVmServiceClient};
@@ -117,8 +117,8 @@ async fn test_enclave_workflow() {
 
     let put_secrets_req_fail = Request::new(ProtoPutSecretsRequest {
         secrets_bundles: vec![SecretsBundle {
-            secrets_box: Some(secrets_box_for_put.to_proto()),
-            env_report: Some(putter_env_report.to_proto()), // Putter uses its EnvReport
+            secrets_box: Some(secrets_box_for_put.clone().into()),
+            env_report: Some(putter_env_report.clone().into()), // Putter uses its EnvReport
         }],
     });
     let put_secrets_resp_fail = secrets_grpc
@@ -147,8 +147,8 @@ async fn test_enclave_workflow() {
     // --- 5. PutSecret succeeds ---
     let put_secrets_req_ok = Request::new(ProtoPutSecretsRequest {
         secrets_bundles: vec![SecretsBundle {
-            secrets_box: Some(secrets_box_for_put.to_proto()),
-            env_report: Some(putter_env_report.to_proto()), // Putter uses its EnvReport
+            secrets_box: Some(secrets_box_for_put.clone().into()),
+            env_report: Some(putter_env_report.clone().into()), // Putter uses its EnvReport
         }],
     });
     let put_secrets_resp_ok = secrets_grpc.put_secrets(put_secrets_req_ok).await.unwrap();
@@ -180,17 +180,17 @@ async fn test_enclave_workflow() {
     info!("Step 6b: Attempting GetSecret (expected fail - no auth for getter)");
     let get_secrets_req_fail = Request::new(ProtoGetSecretsRequest {
         requests: vec![SecretRequest {
-            id: Some(secret_id.to_proto()),
+            id: Some(secret_id.clone().into()),
         }],
         policy_reports: vec![],
-        requester_env_report: Some(getter_env_report.to_proto()), // Getter uses its EnvReport
+        requester_env_report: Some(getter_env_report.clone().into()), // Getter uses its EnvReport
     });
     let get_secrets_resp_fail = secrets_grpc
         .get_secrets(get_secrets_req_fail)
         .await
         .unwrap();
     let secrets_box_fail =
-        SecretsBox::from_proto(get_secrets_resp_fail.into_inner().secrets_box.unwrap());
+        SecretsBox::from(get_secrets_resp_fail.into_inner().secrets_box.unwrap());
     assert!(
         secrets_box_fail.contained_secret_ids.is_empty(),
         "GetSecrets should return empty box"
@@ -213,14 +213,14 @@ async fn test_enclave_workflow() {
     info!("Step 8: Attempting GetSecret (expected success)");
     let get_secrets_req_ok = Request::new(ProtoGetSecretsRequest {
         requests: vec![SecretRequest {
-            id: Some(secret_id.to_proto()),
+            id: Some(secret_id.clone().into()),
         }],
         policy_reports: vec![],
-        requester_env_report: Some(getter_env_report.to_proto()), // Getter uses its EnvReport
+        requester_env_report: Some(getter_env_report.clone().into()), // Getter uses its EnvReport
     });
     let get_secrets_resp_ok = secrets_grpc.get_secrets(get_secrets_req_ok).await.unwrap();
     let secrets_box_ok =
-        SecretsBox::from_proto(get_secrets_resp_ok.into_inner().secrets_box.unwrap());
+        SecretsBox::from(get_secrets_resp_ok.into_inner().secrets_box.unwrap());
     assert_eq!(secrets_box_ok.contained_secret_ids.len(), 1);
     assert_eq!(secrets_box_ok.contained_secret_ids[0], secret_id);
 
@@ -235,17 +235,17 @@ async fn test_enclave_workflow() {
     info!("Step 9: Attempting further GetSecret (expected success - auth not consumed)");
     let get_secrets_req_ok_2 = Request::new(ProtoGetSecretsRequest {
         requests: vec![SecretRequest {
-            id: Some(secret_id.to_proto()),
+            id: Some(secret_id.clone().into()),
         }],
         policy_reports: vec![],
-        requester_env_report: Some(getter_env_report.to_proto()), // Getter uses its EnvReport
+        requester_env_report: Some(getter_env_report.clone().into()), // Getter uses its EnvReport
     });
     let get_secrets_resp_ok_2 = secrets_grpc
         .get_secrets(get_secrets_req_ok_2)
         .await
         .unwrap();
     let secrets_box_ok_2 =
-        SecretsBox::from_proto(get_secrets_resp_ok_2.into_inner().secrets_box.unwrap());
+        SecretsBox::from(get_secrets_resp_ok_2.into_inner().secrets_box.unwrap());
     assert_eq!(secrets_box_ok_2.contained_secret_ids.len(), 1);
     info!("Step 9: Further GetSecret succeeded");
 }
@@ -368,7 +368,7 @@ async fn execute_policy_with_env_report(
 
     let execute_req = Request::new(ProtoExecutePolicyRequest {
         worker_id: worker_id.to_string(),
-        contexts: vec![policy_req_internal.to_proto()],
+        contexts: vec![policy_req_internal.into()],
     });
 
     let execute_resp = runner_grpc
@@ -421,7 +421,7 @@ async fn get_secret_status(
     secret_id: &SecretId,
 ) -> Option<(bool, u64)> {
     let check_req = Request::new(nxcc_interface::proto::enclave::CheckSecretsRequest {
-        ids: vec![secret_id.to_proto()],
+        ids: vec![secret_id.clone().into()],
     });
     let check_resp = secrets_grpc
         .check_secrets(check_req)
@@ -503,8 +503,8 @@ async fn test_put_secrets_mismatched_binding_hash() {
 
     let put_secrets_req = Request::new(ProtoPutSecretsRequest {
         secrets_bundles: vec![SecretsBundle {
-            secrets_box: Some(secrets_box.to_proto()),
-            env_report: Some(putter_env_report_bad_hash.to_proto()),
+            secrets_box: Some(secrets_box.into()),
+            env_report: Some(putter_env_report_bad_hash.into()),
         }],
     });
     let put_secrets_resp = secrets_grpc.put_secrets(put_secrets_req).await.unwrap();
@@ -555,8 +555,8 @@ async fn test_put_secrets_invalid_secrets_box_structure() {
 
     let put_secrets_req = Request::new(ProtoPutSecretsRequest {
         secrets_bundles: vec![SecretsBundle {
-            secrets_box: Some(bad_secrets_box.to_proto()),
-            env_report: Some(putter_env_report_for_bad_box.to_proto()),
+            secrets_box: Some(bad_secrets_box.clone().into()),
+            env_report: Some(putter_env_report_for_bad_box.into()),
         }],
     });
     let put_secrets_resp = secrets_grpc.put_secrets(put_secrets_req).await.unwrap();
@@ -609,8 +609,8 @@ async fn test_put_secrets_decryption_failure() {
 
     let put_secrets_req = Request::new(ProtoPutSecretsRequest {
         secrets_bundles: vec![SecretsBundle {
-            secrets_box: Some(secrets_box_wrong_key.to_proto()),
-            env_report: Some(putter_env_report_for_wrong_key_box.to_proto()),
+            secrets_box: Some(secrets_box_wrong_key.clone().into()),
+            env_report: Some(putter_env_report_for_wrong_key_box.into()),
         }],
     });
     let put_secrets_resp = secrets_grpc.put_secrets(put_secrets_req).await.unwrap();
@@ -664,8 +664,8 @@ async fn test_get_secrets_unauthorized_node() {
     .await;
     let put_req = Request::new(ProtoPutSecretsRequest {
         secrets_bundles: vec![SecretsBundle {
-            secrets_box: Some(secrets_box_put.to_proto()),
-            env_report: Some(putter_env_report.to_proto()),
+            secrets_box: Some(secrets_box_put.clone().into()),
+            env_report: Some(putter_env_report.clone().into()),
         }],
     });
     let put_resp = secrets_grpc.put_secrets(put_req).await.unwrap();
@@ -701,14 +701,14 @@ async fn test_get_secrets_unauthorized_node() {
 
     let get_req_unauth = Request::new(ProtoGetSecretsRequest {
         requests: vec![SecretRequest {
-            id: Some(secret_id.to_proto()),
+            id: Some(secret_id.clone().into()),
         }],
         policy_reports: vec![],
-        requester_env_report: Some(unauthorized_getter_env_report.to_proto()),
+        requester_env_report: Some(unauthorized_getter_env_report.clone().into()),
     });
     let get_resp_unauth = secrets_grpc.get_secrets(get_req_unauth).await.unwrap();
     let secrets_box_unauth =
-        SecretsBox::from_proto(get_resp_unauth.into_inner().secrets_box.unwrap());
+        SecretsBox::from(get_resp_unauth.into_inner().secrets_box.unwrap());
     assert!(
         secrets_box_unauth.contained_secret_ids.is_empty(),
         "Unauthorized GetSecrets should yield empty box"
@@ -718,13 +718,13 @@ async fn test_get_secrets_unauthorized_node() {
     // 4. Verify authorized node *can* get it
     let get_req_auth = Request::new(ProtoGetSecretsRequest {
         requests: vec![SecretRequest {
-            id: Some(secret_id.to_proto()),
+            id: Some(secret_id.clone().into()),
         }],
         policy_reports: vec![],
-        requester_env_report: Some(authorized_getter_env_report.to_proto()),
+        requester_env_report: Some(authorized_getter_env_report.clone().into()),
     });
     let get_resp_auth = secrets_grpc.get_secrets(get_req_auth).await.unwrap();
-    let secrets_box_auth = SecretsBox::from_proto(get_resp_auth.into_inner().secrets_box.unwrap());
+    let secrets_box_auth = SecretsBox::from(get_resp_auth.into_inner().secrets_box.unwrap());
     assert_eq!(secrets_box_auth.contained_secret_ids.len(), 1);
     info!("Test OK: Authorized node successfully retrieved secret");
 }
@@ -740,8 +740,8 @@ async fn test_get_secrets_invalid_requester_report() {
     let secret_id = test_secret_id(2005);
     let getter_node_id = "node-getter-badreport";
 
-    let mut bad_env_report_proto =
-        test_env_report_for_client(getter_node_id, &[0; 32], vec![]).to_proto();
+    let mut bad_env_report_proto: nxcc_interface::proto::interface::EnvReport =
+        test_env_report_for_client(getter_node_id, &[0; 32], vec![]).into();
     // Tamper with the attestation part of the proto directly
     bad_env_report_proto
         .attestation
@@ -751,7 +751,7 @@ async fn test_get_secrets_invalid_requester_report() {
 
     let get_secrets_req = Request::new(ProtoGetSecretsRequest {
         requests: vec![SecretRequest {
-            id: Some(secret_id.to_proto()),
+            id: Some(secret_id.clone().into()),
         }],
         policy_reports: vec![],
         requester_env_report: Some(bad_env_report_proto),
@@ -862,7 +862,7 @@ async fn test_generate_secrets_workflow() {
 
     // 1. Attempt GenerateSecrets without authorization -> Skips, no error
     let gen_req_unauth = Request::new(GenerateSecretsRequest {
-        ids: vec![secret_id_gen.to_proto()],
+        ids: vec![secret_id_gen.clone().into()],
     });
     assert!(secrets_grpc.generate_secrets(gen_req_unauth).await.is_ok());
     assert!(!check_secret_exists(&secrets_grpc, &secret_id_gen).await);
@@ -877,7 +877,7 @@ async fn test_generate_secrets_workflow() {
 
     // 3. GenerateSecrets successfully
     let gen_req_auth = Request::new(GenerateSecretsRequest {
-        ids: vec![secret_id_gen.to_proto()],
+        ids: vec![secret_id_gen.clone().into()],
     });
     assert!(secrets_grpc.generate_secrets(gen_req_auth).await.is_ok());
     assert!(check_secret_exists(&secrets_grpc, &secret_id_gen).await);
@@ -885,7 +885,7 @@ async fn test_generate_secrets_workflow() {
 
     // 4. Attempt GenerateSecrets again for the same ID -> Fails (AlreadyExists)
     let gen_req_dup = Request::new(GenerateSecretsRequest {
-        ids: vec![secret_id_gen.to_proto()],
+        ids: vec![secret_id_gen.clone().into()],
     });
     assert_eq!(
         secrets_grpc
@@ -927,8 +927,8 @@ async fn test_generate_secrets_workflow() {
     .await;
     let put_req = Request::new(ProtoPutSecretsRequest {
         secrets_bundles: vec![SecretsBundle {
-            secrets_box: Some(secrets_box_put.to_proto()),
-            env_report: Some(putter_env_report.to_proto()),
+            secrets_box: Some(secrets_box_put.clone().into()),
+            env_report: Some(putter_env_report.clone().into()),
         }],
     });
     let put_resp = secrets_grpc.put_secrets(put_req).await.unwrap();
@@ -958,13 +958,13 @@ async fn test_generate_secrets_workflow() {
 
     let get_req = Request::new(ProtoGetSecretsRequest {
         requests: vec![SecretRequest {
-            id: Some(secret_id_gen.to_proto()),
+            id: Some(secret_id_gen.clone().into()),
         }],
         policy_reports: vec![],
-        requester_env_report: Some(getter_env_report.to_proto()),
+        requester_env_report: Some(getter_env_report.clone().into()),
     });
     let get_resp = secrets_grpc.get_secrets(get_req).await.unwrap();
-    let secrets_box_get = SecretsBox::from_proto(get_resp.into_inner().secrets_box.unwrap());
+    let secrets_box_get = SecretsBox::from(get_resp.into_inner().secrets_box.unwrap());
     assert_eq!(secrets_box_get.contained_secret_ids.len(), 1); // This was the failing assertion
     assert_eq!(secrets_box_get.contained_secret_ids[0], secret_id_gen);
 

--- a/node/interface/src/types.rs
+++ b/node/interface/src/types.rs
@@ -3,16 +3,6 @@ use serde::{Deserialize, Serialize};
 
 use crate::proto::{enclave, interface};
 
-/// Trait for converting a type to its Protocol Buffers representation
-pub trait IntoProto<P> {
-    fn to_proto(&self) -> P;
-}
-
-/// Trait for converting from a Protocol Buffers representation to a type
-pub trait FromProto<P> {
-    fn from_proto(proto: P) -> Self;
-}
-
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AttestationReport {
     pub ephemeral_public_key: Vec<u8>,
@@ -22,8 +12,8 @@ pub struct AttestationReport {
     pub user_data: Vec<u8>,
 }
 
-impl FromProto<interface::AttestationReport> for AttestationReport {
-    fn from_proto(p: interface::AttestationReport) -> Self {
+impl From<interface::AttestationReport> for AttestationReport {
+    fn from(p: interface::AttestationReport) -> Self {
         Self {
             ephemeral_public_key: p.ephemeral_public_key,
             measurement: p.measurement,
@@ -33,14 +23,25 @@ impl FromProto<interface::AttestationReport> for AttestationReport {
     }
 }
 
-impl IntoProto<interface::AttestationReport> for AttestationReport {
-    fn to_proto(&self) -> interface::AttestationReport {
-        let mut out = interface::AttestationReport::default();
-        out.ephemeral_public_key = self.ephemeral_public_key.clone();
-        out.measurement = self.measurement.clone();
-        out.block_hashes = self.block_hashes.clone();
-        out.user_data = self.user_data.clone();
-        out
+impl From<AttestationReport> for interface::AttestationReport {
+    fn from(value: AttestationReport) -> Self {
+        Self {
+            ephemeral_public_key: value.ephemeral_public_key,
+            measurement: value.measurement,
+            block_hashes: value.block_hashes,
+            user_data: value.user_data,
+        }
+    }
+}
+
+impl From<&AttestationReport> for interface::AttestationReport {
+    fn from(value: &AttestationReport) -> Self {
+        interface::AttestationReport {
+            ephemeral_public_key: value.ephemeral_public_key.clone(),
+            measurement: value.measurement.clone(),
+            block_hashes: value.block_hashes.clone(),
+            user_data: value.user_data.clone(),
+        }
     }
 }
 
@@ -51,8 +52,8 @@ pub struct SecretId {
     pub identity_id: U256,
 }
 
-impl FromProto<interface::SecretIdentifier> for SecretId {
-    fn from_proto(p: interface::SecretIdentifier) -> Self {
+impl From<interface::SecretIdentifier> for SecretId {
+    fn from(p: interface::SecretIdentifier) -> Self {
         Self {
             chain_id: p.chain_id,
             identity_address: p.identity_address.parse().unwrap_or(Address::ZERO), // Handle parse error gracefully
@@ -61,13 +62,23 @@ impl FromProto<interface::SecretIdentifier> for SecretId {
     }
 }
 
-impl IntoProto<interface::SecretIdentifier> for SecretId {
-    fn to_proto(&self) -> interface::SecretIdentifier {
-        let mut out = interface::SecretIdentifier::default();
-        out.chain_id = self.chain_id;
-        out.identity_address = format!("{:#x}", self.identity_address);
-        out.identity_id = self.identity_id.to_string();
-        out
+impl From<SecretId> for interface::SecretIdentifier {
+    fn from(value: SecretId) -> Self {
+        interface::SecretIdentifier {
+            chain_id: value.chain_id,
+            identity_address: format!("{:#x}", value.identity_address),
+            identity_id: value.identity_id.to_string(),
+        }
+    }
+}
+
+impl From<&SecretId> for interface::SecretIdentifier {
+    fn from(value: &SecretId) -> Self {
+        interface::SecretIdentifier {
+            chain_id: value.chain_id,
+            identity_address: format!("{:#x}", value.identity_address),
+            identity_id: value.identity_id.to_string(),
+        }
     }
 }
 
@@ -77,8 +88,8 @@ pub struct ConsumerInfo {
     pub signature: Vec<u8>,
 }
 
-impl FromProto<interface::ConsumerInfo> for ConsumerInfo {
-    fn from_proto(p: interface::ConsumerInfo) -> Self {
+impl From<interface::ConsumerInfo> for ConsumerInfo {
+    fn from(p: interface::ConsumerInfo) -> Self {
         Self {
             code_hash: p.code_hash,
             signature: p.signature,
@@ -86,12 +97,21 @@ impl FromProto<interface::ConsumerInfo> for ConsumerInfo {
     }
 }
 
-impl IntoProto<interface::ConsumerInfo> for ConsumerInfo {
-    fn to_proto(&self) -> interface::ConsumerInfo {
-        let mut out = interface::ConsumerInfo::default();
-        out.code_hash = self.code_hash.clone();
-        out.signature = self.signature.clone();
-        out
+impl From<ConsumerInfo> for interface::ConsumerInfo {
+    fn from(value: ConsumerInfo) -> Self {
+        interface::ConsumerInfo {
+            code_hash: value.code_hash,
+            signature: value.signature,
+        }
+    }
+}
+
+impl From<&ConsumerInfo> for interface::ConsumerInfo {
+    fn from(value: &ConsumerInfo) -> Self {
+        interface::ConsumerInfo {
+            code_hash: value.code_hash.clone(),
+            signature: value.signature.clone(),
+        }
     }
 }
 
@@ -101,21 +121,27 @@ pub struct SecretRequest {
     pub consumer: ConsumerInfo,
 }
 
-impl FromProto<interface::SecretRequest> for SecretRequest {
-    fn from_proto(p: interface::SecretRequest) -> Self {
+impl From<interface::SecretRequest> for SecretRequest {
+    fn from(p: interface::SecretRequest) -> Self {
         Self {
-            secret_id: SecretId::from_proto(p.secret_id.unwrap_or_default()),
-            consumer: ConsumerInfo::from_proto(p.consumer.unwrap_or_default()),
+            secret_id: p
+                .secret_id
+                .map(SecretId::from)
+                .unwrap_or_else(|| SecretId::from(interface::SecretIdentifier::default())),
+            consumer: p
+                .consumer
+                .map(ConsumerInfo::from)
+                .unwrap_or_else(|| ConsumerInfo::from(interface::ConsumerInfo::default())),
         }
     }
 }
 
-impl IntoProto<interface::SecretRequest> for SecretRequest {
-    fn to_proto(&self) -> interface::SecretRequest {
-        let mut out = interface::SecretRequest::default();
-        out.secret_id = Some(self.secret_id.to_proto());
-        out.consumer = Some(self.consumer.to_proto());
-        out
+impl From<SecretRequest> for interface::SecretRequest {
+    fn from(value: SecretRequest) -> Self {
+        interface::SecretRequest {
+            secret_id: Some(value.secret_id.into()),
+            consumer: Some(value.consumer.into()),
+        }
     }
 }
 
@@ -126,23 +152,36 @@ pub struct EnvReport {
     pub node_id: String,
 }
 
-impl FromProto<interface::EnvReport> for EnvReport {
-    fn from_proto(p: interface::EnvReport) -> Self {
+impl From<interface::EnvReport> for EnvReport {
+    fn from(p: interface::EnvReport) -> Self {
         Self {
-            attestation: AttestationReport::from_proto(p.attestation.unwrap_or_default()),
+            attestation: p
+                .attestation
+                .map(AttestationReport::from)
+                .unwrap_or_else(|| AttestationReport::from(interface::AttestationReport::default())),
             operator_signature: p.operator_signature,
             node_id: p.node_id,
         }
     }
 }
 
-impl IntoProto<interface::EnvReport> for EnvReport {
-    fn to_proto(&self) -> interface::EnvReport {
-        let mut out = interface::EnvReport::default();
-        out.attestation = Some(self.attestation.to_proto());
-        out.operator_signature = self.operator_signature.clone();
-        out.node_id = self.node_id.clone();
-        out
+impl From<EnvReport> for interface::EnvReport {
+    fn from(value: EnvReport) -> Self {
+        interface::EnvReport {
+            attestation: Some(value.attestation.into()),
+            operator_signature: value.operator_signature,
+            node_id: value.node_id,
+        }
+    }
+}
+
+impl From<&EnvReport> for interface::EnvReport {
+    fn from(value: &EnvReport) -> Self {
+        interface::EnvReport {
+            attestation: Some(value.attestation.clone().into()),
+            operator_signature: value.operator_signature.clone(),
+            node_id: value.node_id.clone(),
+        }
     }
 }
 
@@ -180,8 +219,8 @@ impl SecretsBox {
     }
 }
 
-impl FromProto<interface::SecretsBox> for SecretsBox {
-    fn from_proto(p: interface::SecretsBox) -> Self {
+impl From<interface::SecretsBox> for SecretsBox {
+    fn from(p: interface::SecretsBox) -> Self {
         Self {
             encrypted_payload: p.encrypted_payload,
             sender_public_key: p.sender_public_key,
@@ -189,24 +228,40 @@ impl FromProto<interface::SecretsBox> for SecretsBox {
             contained_secret_ids: p
                 .contained_secret_ids
                 .into_iter()
-                .map(SecretId::from_proto)
+                .map(SecretId::from)
                 .collect(),
         }
     }
 }
 
-impl IntoProto<interface::SecretsBox> for SecretsBox {
-    fn to_proto(&self) -> interface::SecretsBox {
-        let mut out = interface::SecretsBox::default();
-        out.encrypted_payload = self.encrypted_payload.clone();
-        out.sender_public_key = self.sender_public_key.clone();
-        out.alg = self.alg.clone();
-        out.contained_secret_ids = self
-            .contained_secret_ids
-            .iter()
-            .map(|id| id.to_proto())
-            .collect();
-        out
+impl From<SecretsBox> for interface::SecretsBox {
+    fn from(value: SecretsBox) -> Self {
+        interface::SecretsBox {
+            encrypted_payload: value.encrypted_payload,
+            sender_public_key: value.sender_public_key,
+            alg: value.alg,
+            contained_secret_ids: value
+                .contained_secret_ids
+                .into_iter()
+                .map(Into::into)
+                .collect(),
+        }
+    }
+}
+
+impl From<&SecretsBox> for interface::SecretsBox {
+    fn from(value: &SecretsBox) -> Self {
+        interface::SecretsBox {
+            encrypted_payload: value.encrypted_payload.clone(),
+            sender_public_key: value.sender_public_key.clone(),
+            alg: value.alg.clone(),
+            contained_secret_ids: value
+                .contained_secret_ids
+                .iter()
+                .cloned()
+                .map(Into::into)
+                .collect(),
+        }
     }
 }
 
@@ -218,22 +273,38 @@ pub struct PolicyExecutionRequest {
     pub env_report: EnvReport, // The EnvReport of the entity being evaluated
 }
 
-impl FromProto<interface::PolicyExecutionRequest> for PolicyExecutionRequest {
-    fn from_proto(p: interface::PolicyExecutionRequest) -> Self {
+impl From<interface::PolicyExecutionRequest> for PolicyExecutionRequest {
+    fn from(p: interface::PolicyExecutionRequest) -> Self {
         Self {
-            secret_ids: p.secret_ids.into_iter().map(SecretId::from_proto).collect(),
-            consumer: ConsumerInfo::from_proto(p.consumer.unwrap_or_default()),
-            env_report: EnvReport::from_proto(p.env_report.unwrap_or_default()),
+            secret_ids: p.secret_ids.into_iter().map(SecretId::from).collect(),
+            consumer: p
+                .consumer
+                .map(ConsumerInfo::from)
+                .unwrap_or_else(|| ConsumerInfo::from(interface::ConsumerInfo::default())),
+            env_report: p
+                .env_report
+                .map(EnvReport::from)
+                .unwrap_or_else(|| EnvReport::from(interface::EnvReport::default())),
         }
     }
 }
 
-impl IntoProto<interface::PolicyExecutionRequest> for PolicyExecutionRequest {
-    fn to_proto(&self) -> interface::PolicyExecutionRequest {
+impl From<PolicyExecutionRequest> for interface::PolicyExecutionRequest {
+    fn from(value: PolicyExecutionRequest) -> Self {
         interface::PolicyExecutionRequest {
-            secret_ids: self.secret_ids.iter().map(|id| id.to_proto()).collect(),
-            consumer: Some(self.consumer.to_proto()),
-            env_report: Some(self.env_report.to_proto()),
+            secret_ids: value.secret_ids.into_iter().map(Into::into).collect(),
+            consumer: Some(value.consumer.into()),
+            env_report: Some(value.env_report.into()),
+        }
+    }
+}
+
+impl From<&PolicyExecutionRequest> for interface::PolicyExecutionRequest {
+    fn from(value: &PolicyExecutionRequest) -> Self {
+        interface::PolicyExecutionRequest {
+            secret_ids: value.secret_ids.iter().cloned().map(Into::into).collect(),
+            consumer: Some(value.consumer.clone().into()),
+            env_report: Some(value.env_report.clone().into()),
         }
     }
 }
@@ -253,8 +324,8 @@ pub struct TcpAddress {
     pub port: u32,
 }
 
-impl FromProto<enclave::TcpAddress> for TcpAddress {
-    fn from_proto(p: enclave::TcpAddress) -> Self {
+impl From<enclave::TcpAddress> for TcpAddress {
+    fn from(p: enclave::TcpAddress) -> Self {
         Self {
             host: p.host,
             port: p.port,
@@ -262,11 +333,20 @@ impl FromProto<enclave::TcpAddress> for TcpAddress {
     }
 }
 
-impl IntoProto<enclave::TcpAddress> for TcpAddress {
-    fn to_proto(&self) -> enclave::TcpAddress {
+impl From<TcpAddress> for enclave::TcpAddress {
+    fn from(value: TcpAddress) -> Self {
         enclave::TcpAddress {
-            host: self.host.clone(),
-            port: self.port,
+            host: value.host,
+            port: value.port,
+        }
+    }
+}
+
+impl From<&TcpAddress> for enclave::TcpAddress {
+    fn from(value: &TcpAddress) -> Self {
+        enclave::TcpAddress {
+            host: value.host.clone(),
+            port: value.port,
         }
     }
 }
@@ -276,17 +356,21 @@ pub struct UdsAddress {
     pub path: String,
 }
 
-impl FromProto<enclave::UdsAddress> for UdsAddress {
-    fn from_proto(p: enclave::UdsAddress) -> Self {
+impl From<enclave::UdsAddress> for UdsAddress {
+    fn from(p: enclave::UdsAddress) -> Self {
         Self { path: p.path }
     }
 }
 
-impl IntoProto<enclave::UdsAddress> for UdsAddress {
-    fn to_proto(&self) -> enclave::UdsAddress {
-        enclave::UdsAddress {
-            path: self.path.clone(),
-        }
+impl From<UdsAddress> for enclave::UdsAddress {
+    fn from(value: UdsAddress) -> Self {
+        enclave::UdsAddress { path: value.path }
+    }
+}
+
+impl From<&UdsAddress> for enclave::UdsAddress {
+    fn from(value: &UdsAddress) -> Self {
+        enclave::UdsAddress { path: value.path.clone() }
     }
 }
 
@@ -296,8 +380,8 @@ pub struct VsockAddress {
     pub port: u32,
 }
 
-impl FromProto<enclave::VsockAddress> for VsockAddress {
-    fn from_proto(p: enclave::VsockAddress) -> Self {
+impl From<enclave::VsockAddress> for VsockAddress {
+    fn from(p: enclave::VsockAddress) -> Self {
         Self {
             cid: p.cid,
             port: p.port,
@@ -305,11 +389,20 @@ impl FromProto<enclave::VsockAddress> for VsockAddress {
     }
 }
 
-impl IntoProto<enclave::VsockAddress> for VsockAddress {
-    fn to_proto(&self) -> enclave::VsockAddress {
+impl From<VsockAddress> for enclave::VsockAddress {
+    fn from(value: VsockAddress) -> Self {
         enclave::VsockAddress {
-            cid: self.cid,
-            port: self.port,
+            cid: value.cid,
+            port: value.port,
+        }
+    }
+}
+
+impl From<&VsockAddress> for enclave::VsockAddress {
+    fn from(value: &VsockAddress) -> Self {
+        enclave::VsockAddress {
+            cid: value.cid,
+            port: value.port,
         }
     }
 }
@@ -321,29 +414,36 @@ pub enum VmAddress {
     Vsock(VsockAddress),
 }
 
-impl FromProto<enclave::VmAddress> for VmAddress {
-    fn from_proto(p: enclave::VmAddress) -> Self {
+impl From<enclave::VmAddress> for VmAddress {
+    fn from(p: enclave::VmAddress) -> Self {
         match p.address_type {
-            Some(enclave::vm_address::AddressType::Tcp(tcp)) => {
-                VmAddress::Tcp(TcpAddress::from_proto(tcp))
-            }
-            Some(enclave::vm_address::AddressType::Uds(uds)) => {
-                VmAddress::Uds(UdsAddress::from_proto(uds))
-            }
-            Some(enclave::vm_address::AddressType::Vsock(vsock)) => {
-                VmAddress::Vsock(VsockAddress::from_proto(vsock))
-            }
+            Some(enclave::vm_address::AddressType::Tcp(tcp)) => VmAddress::Tcp(TcpAddress::from(tcp)),
+            Some(enclave::vm_address::AddressType::Uds(uds)) => VmAddress::Uds(UdsAddress::from(uds)),
+            Some(enclave::vm_address::AddressType::Vsock(vsock)) => VmAddress::Vsock(VsockAddress::from(vsock)),
             None => panic!("VmAddress proto is missing address_type"), // Or return an error
         }
     }
 }
 
-impl IntoProto<enclave::VmAddress> for VmAddress {
-    fn to_proto(&self) -> enclave::VmAddress {
-        let address_type = match self {
-            VmAddress::Tcp(tcp) => enclave::vm_address::AddressType::Tcp(tcp.to_proto()),
-            VmAddress::Uds(uds) => enclave::vm_address::AddressType::Uds(uds.to_proto()),
-            VmAddress::Vsock(vsock) => enclave::vm_address::AddressType::Vsock(vsock.to_proto()),
+impl From<VmAddress> for enclave::VmAddress {
+    fn from(value: VmAddress) -> Self {
+        let address_type = match value {
+            VmAddress::Tcp(tcp) => enclave::vm_address::AddressType::Tcp(tcp.into()),
+            VmAddress::Uds(uds) => enclave::vm_address::AddressType::Uds(uds.into()),
+            VmAddress::Vsock(vsock) => enclave::vm_address::AddressType::Vsock(vsock.into()),
+        };
+        enclave::VmAddress {
+            address_type: Some(address_type),
+        }
+    }
+}
+
+impl From<&VmAddress> for enclave::VmAddress {
+    fn from(value: &VmAddress) -> Self {
+        let address_type = match value {
+            VmAddress::Tcp(tcp) => enclave::vm_address::AddressType::Tcp(tcp.into()),
+            VmAddress::Uds(uds) => enclave::vm_address::AddressType::Uds(uds.into()),
+            VmAddress::Vsock(vsock) => enclave::vm_address::AddressType::Vsock(vsock.into()),
         };
         enclave::VmAddress {
             address_type: Some(address_type),

--- a/node/vm/base/src/client/mod.rs
+++ b/node/vm/base/src/client/mod.rs
@@ -12,7 +12,7 @@ use nxcc_interface::{
         ListRunningWorkersRequest, StartWorkerRequest, StopWorkerRequest, TrustedConfig,
         UntrustedConfig, WorkerStatus,
     },
-    types::{AttestationReport, FromProto as _},
+    types::AttestationReport,
 };
 use thiserror::Error;
 #[cfg(feature = "uds")]
@@ -244,7 +244,7 @@ impl VmClient for VmServiceClient {
         let response = self.inner.get_attestation(request).await?.into_inner();
 
         match response.report {
-            Some(report) => Ok(AttestationReport::from_proto(report)),
+            Some(report) => Ok(AttestationReport::from(report)),
             None => Err(ClientError::Grpc(Status::internal(
                 "No attestation report received",
             ))),

--- a/node/vm/base/src/server.rs
+++ b/node/vm/base/src/server.rs
@@ -87,7 +87,6 @@ use nxcc_interface::{
         StartWorkerResponse, StopWorkerRequest, StopWorkerResponse, WorkerStatus,
         vm_server::{Vm, VmServer},
     },
-    types::IntoProto as _,
 };
 
 pub struct VmServiceGrpc<T: VmRuntime> {
@@ -211,7 +210,7 @@ impl<T: VmRuntime> Vm for VmServiceGrpc<T> {
         match self.runtime.get_attestation(req.user_data).await {
             Ok(report) => {
                 debug!("Successfully retrieved attestation report");
-                let proto_report = report.to_proto();
+                let proto_report: nxcc_interface::proto::interface::AttestationReport = report.into();
                 Ok(Response::new(GetAttestationResponse {
                     report: Some(proto_report),
                 }))


### PR DESCRIPTION
## Summary
- use `From` for conversions in interface crate
- adjust all modules to new conversion style
- add reference-based `From` impls
- update tests

## Testing
- `cargo test --workspace --exclude nxcc-workerd -- --skip client::tests::test_client_error_handling --skip client::tests::test_client_operations --skip tests::test_e2e_with_client_binding --quiet`